### PR TITLE
Add the app before bundling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,13 @@ RUN yum -y install --setopt=tsflags=nodocs \
 ENV WORKDIR /opt/mock-collector/
 WORKDIR $WORKDIR
 
-COPY Gemfile $WORKDIR
+COPY . $WORKDIR
 RUN echo "gem: --no-document" > ~/.gemrc && \
     gem install bundler --conservative --without development:test && \
     bundle install --jobs 8 --retry 3 && \
     find ${RUBY_GEMS_ROOT}/gems/ | grep "\.s\?o$" | xargs rm -rvf && \
     rm -rvf ${RUBY_GEMS_ROOT}/cache/* && \
     rm -rvf /root/.bundle/cache
-
-COPY . $WORKDIR
 
 RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR


### PR DESCRIPTION
The bundle command checks the Gemfile and the Gemfile references the
gemspec and the gemspec looks for the version class and that fails

@slemrmartin The alternative is to specify all the dependencies in the Gemfile like @agrare does here: https://github.com/agrare/openshift-collector/blob/ad8421466ef5f11a707cd33dd8d863bfd9ed445f/Gemfile

Although I'm not sure why he also has a gemspec there ...