### PR TITLE
InventoryCollectionStorage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "more_core_extensions"
 gem "optimist"
 gem "recursive-open-struct"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
+gem 'topological_inventory-provider_common', :git => 'https://github.com/slemrmartin/topological_inventory-provider_common', :branch => "master"
 
 group :development, :test do
   gem "rspec", "~> 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "more_core_extensions"
 gem "optimist"
 gem "recursive-open-struct"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
-gem 'topological_inventory-provider_common', :git => 'https://github.com/slemrmartin/topological_inventory-provider_common', :branch => "master"
 
 group :development, :test do
   gem "rspec", "~> 3.0"

--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -1,6 +1,6 @@
 require "config"
 require "concurrent"
-require "topological_inventory/provider_common/collector"
+require "topological_inventory-ingress_api-client/collector"
 require "topological_inventory/mock_source/parser"
 require "topological_inventory/mock_source/server"
 

--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -1,7 +1,6 @@
-require "topological_inventory-ingress_api-client"
-
 require "config"
 require "concurrent"
+require "topological_inventory/provider_common/collector"
 require "topological_inventory/mock_source/parser"
 require "topological_inventory/mock_source/server"
 

--- a/lib/topological_inventory/mock_source/openshift/parser.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser.rb
@@ -25,20 +25,6 @@ module TopologicalInventory
         include TopologicalInventory::MockSource::Openshift::Parser::ClusterServicePlan
         include TopologicalInventory::MockSource::Openshift::Parser::ServiceInstance
 
-        def initialize
-          super
-
-          # TODO: merge with Server
-          entity_types = %i(containers container_groups container_nodes container_projects container_images
-                          container_templates service_instances service_offerings service_plans
-                          container_group_tags container_node_tags container_project_tags container_image_tags
-                          container_template_tags service_offering_tags service_offering_icons)
-
-          self.collections = entity_types.each_with_object({}).each do |entity_type, collections|
-            collections[entity_type] = TopologicalInventoryIngressApiClient::InventoryCollection.new(:name => entity_type, :data => [])
-          end
-        end
-
         private
 
         def parse_base_item(entity)

--- a/lib/topological_inventory/mock_source/openshift/parser/cluster_service_class.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/cluster_service_class.rb
@@ -17,7 +17,7 @@ module TopologicalInventory
             icon_class   = (service_class.spec&.externalMetadata || {})["console.openshift.io/iconClass"]
             @icons_cache << icon_class
 
-            service_offering = TopologicalInventoryIngressApiClient::ServiceOffering.new(
+            service_offering = collections.service_offerings.build(
               :source_ref            => service_class.spec.externalID,
               :name                  => service_class.spec&.externalName,
               :description           => service_class.spec&.description,
@@ -30,7 +30,6 @@ module TopologicalInventory
               :service_offering_icon => lazy_find(:service_offering_icons, :source_ref => icon_class)
             )
 
-            collections[:service_offerings].data << service_offering
             parse_service_offering_tags(service_offering.source_ref, service_class.spec&.tags)
 
             service_offering
@@ -46,14 +45,12 @@ module TopologicalInventory
 
             return if icons_cache.empty?
 
-            collections[:service_offering_icons].data.concat(
-              icons_cache.map do |icon|
-                TopologicalInventoryIngressApiClient::ServiceOfferingIcon.new(
-                  :source_ref => icon,
-                  :data       => fetch_icon(icon)
-                )
-              end
-            )
+            icons_cache.map do |icon|
+              collections.service_offering_icons.build(
+                :source_ref => icon,
+                :data       => fetch_icon(icon)
+              )
+            end
           end
 
           private
@@ -76,7 +73,7 @@ module TopologicalInventory
             (tags || []).each do |key|
               next if key.empty?
 
-              collections[:service_offering_tags].data << TopologicalInventoryIngressApiClient::ServiceOfferingTag.new(
+              collections.service_offering_tags.build(
                 :service_offering => lazy_find(:service_offerings, :source_ref => source_ref),
                 :tag              => lazy_find(:tags, :name => key),
                 :value            => '',

--- a/lib/topological_inventory/mock_source/openshift/parser/cluster_service_plan.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/cluster_service_plan.rb
@@ -12,7 +12,7 @@ module TopologicalInventory
             cluster_service_class_name = service_plan.spec&.clusterServiceClassRef&.name
             service_offering           = lazy_find(:service_offerings, :source_ref => service_plan&.spec&.clusterServiceClassRef&.name) if cluster_service_class_name
 
-            service_plan_data = TopologicalInventoryIngressApiClient::ServicePlan.new(
+            service_plan_data = collections.service_plans.build(
               :source_ref         => service_plan.spec.externalID,
               :name               => service_plan.spec.externalName,
               :description        => service_plan.spec.description,
@@ -21,8 +21,6 @@ module TopologicalInventory
               :create_json_schema => service_plan.spec&.instanceCreateParameterSchema,
               :service_offering   => service_offering,
             )
-
-            collections[:service_plans].data << service_plan_data
 
             service_plan_data
           end

--- a/lib/topological_inventory/mock_source/openshift/parser/image.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/image.rb
@@ -11,13 +11,12 @@ module TopologicalInventory
           def parse_image(image)
             image_name = parse_image_name(image)
 
-            container_image = TopologicalInventoryIngressApiClient::ContainerImage.new(
+            container_image = collections.container_images.build(
               parse_base_item(image).merge(
                 :name => image_name
               )
             )
 
-            collections[:container_images].data << container_image
             parse_image_tags(container_image.source_ref, image.metadata&.labels&.to_h)
             parse_image_tags(container_image.source_ref, image.dockerImageMetadata&.Config&.Labels&.to_h)
 
@@ -33,7 +32,7 @@ module TopologicalInventory
 
           def parse_image_tags(source_ref, tags)
             (tags || {}).each do |key, value|
-              collections[:container_image_tags].data << TopologicalInventoryIngressApiClient::ContainerImageTag.new(
+              collections.container_image_tags.build(
                 :container_image => lazy_find(:container_images, :source_ref => source_ref),
                 :tag             => lazy_find(:tags, :name => key),
                 :value           => value,

--- a/lib/topological_inventory/mock_source/openshift/parser/namespace.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/namespace.rb
@@ -9,11 +9,10 @@ module TopologicalInventory
           end
 
           def parse_namespace(namespace)
-            container_project = TopologicalInventoryIngressApiClient::ContainerProject.new(
+            container_project = collections.container_projects.build(
               parse_base_item(namespace)
             )
 
-            collections[:container_projects].data << container_project
             parse_namespace_tags(container_project.source_ref, namespace.metadata&.labels&.to_h)
 
             container_project
@@ -28,7 +27,7 @@ module TopologicalInventory
 
           def parse_namespace_tags(source_ref, tags)
             (tags || {}).each do |key, value|
-              collections[:container_project_tags].data << TopologicalInventoryIngressApiClient::ContainerProjectTag.new(
+              collections.container_project_tags.build(
                 :container_project => lazy_find(:container_projects, :source_ref => source_ref),
                 :tag               => lazy_find(:tags, :name => key),
                 :value             => value,

--- a/lib/topological_inventory/mock_source/openshift/parser/node.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/node.rb
@@ -14,7 +14,7 @@ module TopologicalInventory
               memory = parse_quantity(node.status.capacity&.memory)
             end
 
-            container_node = TopologicalInventoryIngressApiClient::ContainerNode.new(
+            container_node = collections.container_nodes.build(
               parse_base_item(node).merge(
                 :cpus     => cpus,
                 :memory   => memory,
@@ -22,7 +22,6 @@ module TopologicalInventory
               )
             )
 
-            collections[:container_nodes].data << container_node
             parse_node_tags(container_node.source_ref, node.metadata&.labels&.to_h)
 
             container_node
@@ -37,7 +36,7 @@ module TopologicalInventory
 
           def parse_node_tags(source_ref, tags)
             (tags || {}).each do |key, value|
-              collections[:container_node_tags].data << TopologicalInventoryIngressApiClient::ContainerNodeTag.new(
+              collections.container_node_tags.build(
                 :container_node => lazy_find(:container_nodes, :source_ref => source_ref),
                 :tag            => lazy_find(:tags, :name => key),
                 :value          => value,

--- a/lib/topological_inventory/mock_source/openshift/parser/service_instance.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/service_instance.rb
@@ -15,15 +15,13 @@ module TopologicalInventory
             service_offering           = lazy_find(:service_offerings, :source_ref => cluster_service_class_name) if cluster_service_class_name
             service_plan               = lazy_find(:service_plans, :source_ref => cluster_service_plan_name) if cluster_service_plan_name
 
-            service_instance = TopologicalInventoryIngressApiClient::ServiceInstance.new(
+            service_instance = collections.service_instances.build(
               :source_ref        => service_instance.spec.externalID,
               :name              => service_instance.spec.externalName,
               :source_created_at => service_instance.metadata.creationTimestamp,
               :service_offering  => service_offering,
               :service_plan      => service_plan,
             )
-
-            collections[:service_instances].data << service_instance
 
             service_instance
           end

--- a/lib/topological_inventory/mock_source/openshift/parser/template.rb
+++ b/lib/topological_inventory/mock_source/openshift/parser/template.rb
@@ -9,13 +9,12 @@ module TopologicalInventory
           end
 
           def parse_template(template)
-            container_template = TopologicalInventoryIngressApiClient::ContainerTemplate.new(
+            container_template = collections.container_templates.build(
               parse_base_item(template).merge(
                 :container_project => lazy_find_namespace(template.metadata&.namespace)
               )
             )
 
-            collections[:container_templates].data << container_template
             parse_template_tags(container_template.source_ref, template.metadata&.labels&.to_h)
 
             container_template
@@ -30,7 +29,7 @@ module TopologicalInventory
 
           def parse_template_tags(source_ref, tags)
             (tags || {}).each do |key, value|
-              collections[:container_template_tags].data << TopologicalInventoryIngressApiClient::ContainerTemplateTag.new(
+              collections.container_template_tags.build(
                 :container_template => lazy_find(:container_templates, :source_ref => source_ref),
                 :tag                => lazy_find(:tags, :name => key),
                 :value              => value,

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -8,7 +8,7 @@ module TopologicalInventory
       delegate :add_collection, :to => :collections
 
       def initialize
-        @collections = TopologicalInventory::ProviderCommon::Collector::InventoryCollectionStorage.new
+        @collections = TopologicalInventoryIngressApiClient::Collector::InventoryCollectionStorage.new
 
         self.resource_timestamp = Time.now.utc
       end

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -5,7 +5,11 @@ module TopologicalInventory
     class Parser
       attr_accessor :collections, :resource_timestamp
 
+      delegate :add_collection, :to => :collections
+
       def initialize
+        @collections = TopologicalInventory::ProviderCommon::Collector::InventoryCollectionStorage.new
+
         self.resource_timestamp = Time.now.utc
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,5 +16,5 @@ Dir[File.join(spec_path, "support/**/*.rb")].each { |f| require f }
 #
 # You can add local requires to /lib/mock/require.dev.rb
 #
-require_dev_path = File.join(spec_path, "../lib/topological_inventory/mock_source", "require.dev.rb")
+require_dev_path = File.join(spec_path, "../lib", "require.dev.rb")
 require require_dev_path if File.exist?(require_dev_path)


### PR DESCRIPTION
`InventoryCollection` and objects are built and defined in similar way as in ManageIQ. 

They are using methods `add_collection` and `build`. 
But `add_collection` is not neccessary, because list of available collections are defined by models in `TopologicalInventoryIngressApiClient`

---

* [x] **depends on**: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/25
* Same as https://github.com/ManageIQ/topological_inventory-collector-openshift/pull/28