### PR TITLE
Add loop for avoiding pods error

### DIFF
--- a/bin/mock-collector
+++ b/bin/mock-collector
@@ -41,3 +41,4 @@ TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}
 collector = TopologicalInventory::MockSource::Collector.new(args[:source], args[:config], args[:amounts])
 collector.collect!
 
+loop {}


### PR DESCRIPTION
When full refresh ends, then container should end in loop. Otherwise pods report error and are restarted. 