### PR TITLE
Configurable amounts for subcollections + tags namespace

### DIFF
--- a/config/amounts/amazon/default.yml
+++ b/config/amounts/amazon/default.yml
@@ -4,8 +4,11 @@ amounts:
   service_instances: 50     # belongs_to [:source_region, :service_offering, :service_plan]
   service_offerings: 100    # belongs_to [:source_region]
   service_offering_icons: 50
+  service_offering_tags: 50
   service_plans: 150        # belongs_to [:source_region, :service_offering]
   source_regions: 50
   volumes: 100              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 2
   volume_types: 50
   vms: 100                  # belongs_to [:flavor]
+  vm_tags: 60

--- a/config/amounts/amazon/large.yml
+++ b/config/amounts/amazon/large.yml
@@ -4,8 +4,11 @@ amounts:
   service_instances: 50000     # belongs_to [:source_region, :service_offering, :service_plan]
   service_offerings: 100000    # belongs_to [:source_region]
   service_offering_icons: 50000
+  service_offering_tags: 100000
   service_plans: 150000        # belongs_to [:source_region, :service_offering]
   source_regions: 50000
   volumes: 100000              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 1000
   volume_types: 50000
   vms: 100000                  # belongs_to [:flavor]
+  vm_tags: 50000

--- a/config/amounts/amazon/small.yml
+++ b/config/amounts/amazon/small.yml
@@ -4,8 +4,11 @@ amounts:
   service_instances: 5     # belongs_to [:source_region, :service_offering, :service_plan]
   service_offerings: 10    # belongs_to [:source_region]
   service_offering_icons: 5
+  service_offering_tags: 5
   service_plans: 15        # belongs_to [:source_region, :service_offering]
   source_regions: 5
   volumes: 10              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 2
   volume_types: 5
   vms: 10                  # belongs_to [:flavor]
+  vm_tags: 6

--- a/config/amounts/default.yml
+++ b/config/amounts/default.yml
@@ -1,16 +1,25 @@
 # Number of generated items
 amounts:
   container_images: 50
+  container_image_tags: 13
   container_groups: 50
-  container_projects: 10
+  containers: 150
+  container_group_tags: 5
   container_nodes: 50
+  container_node_tags: 10
+  container_projects: 10
+  container_project_tags: 7
   container_templates: 50
+  container_template_tags: 10
   flavors: 50
   service_instances: 50     # belongs_to [:source_region, :service_offering, :service_plan]
   service_offerings: 100    # belongs_to [:source_region]
+  service_offering_tags: 50
   service_offering_icons: 5
   service_plans: 150        # belongs_to [:source_region, :service_offering]
   source_regions: 50
   volumes: 100              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 2
   volume_types: 50
   vms: 100                  # belongs_to [:flavor]
+  vm_tags: 60

--- a/config/amounts/large.yml
+++ b/config/amounts/large.yml
@@ -1,16 +1,25 @@
 # Number of generated items
 amounts:
   container_images: 50000
+  container_image_tags: 10000
   container_groups: 1000000
+  containers: 10000000
+  container_group_tags: 40000
   container_nodes: 500000
+  container_node_tags: 10
   container_projects: 10000
+  container_project_tags: 5000
   container_templates: 50000
+  container_template_tags: 100000
   flavors: 50000
   service_instances: 100000
   service_offerings: 100000
+  service_offering_tags: 100000
   service_offering_icons: 5000
   service_plans: 500000
   source_regions: 50000
   volumes: 100000              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 1000
   volume_types: 50000
   vms: 100000                  # belongs_to [:flavor]
+  vm_tags: 50000

--- a/config/amounts/openshift/default.yml
+++ b/config/amounts/openshift/default.yml
@@ -1,12 +1,19 @@
 # Number of generated items
 amounts:
   container_images: 50
+  container_image_tags: 13
   container_groups: 50
+  containers: 150
+  container_group_tags: 5
   container_projects: 10
+  container_project_tags: 7
   container_nodes: 50
+  container_node_tags: 10
   container_templates: 50
+  container_template_tags: 10
   service_instances: 10
   service_offerings: 10
+  service_offering_tags: 50
   service_offering_icons: 5
   service_plans: 50
   source_regions: 5 # amazon IC

--- a/config/amounts/openshift/large.yml
+++ b/config/amounts/openshift/large.yml
@@ -1,12 +1,19 @@
 # Number of generated items
 amounts:
   container_images: 50000
+  container_image_tags: 10000
   container_groups: 1000000
+  containers: 10000000
+  container_group_tags: 40000
   container_nodes: 500000
+  container_node_tags: 10
   container_projects: 10000
+  container_project_tags: 5000
   container_templates: 50000
+  container_template_tags: 100000
   service_instances: 100000
   service_offerings: 100000
+  service_offering_tags: 100000
   service_offering_icons: 5000
   service_plans: 500000
   source_regions: 5

--- a/config/amounts/openshift/small.yml
+++ b/config/amounts/openshift/small.yml
@@ -1,12 +1,18 @@
 # Number of generated items
 amounts:
   container_images: 5
+  container_image_tags: 13
   container_groups: 10
+  container_group_tags: 4
   container_nodes: 5
+  container_node_tags: 10
   container_projects: 2
+  container_project_tags: 7
   container_templates: 5
+  container_template_tags: 10
   service_instances: 10
   service_offerings: 2
+  service_offering_tags: 5
   service_offering_icons: 2
   service_plans: 5
   source_regions: 5

--- a/config/amounts/openshift/test.yml
+++ b/config/amounts/openshift/test.yml
@@ -1,13 +1,20 @@
 # Number of generated items
 amounts:
   container_images: 5
+  container_image_tags: 13
   container_groups: 10
+  containers: 15
+  container_group_tags: 4
   container_projects: 2
+  container_project_tags: 7
   container_nodes: 5
+  container_node_tags: 10
   container_templates: 5
+  container_template_tags: 10
   service_instances: 10
   service_offerings: 2
   service_offering_icons: 2
+  service_offering_tags: 5
   service_plans: 5
   source_regions: 5
 

--- a/config/amounts/small.yml
+++ b/config/amounts/small.yml
@@ -1,16 +1,25 @@
 # Number of generated items
 amounts:
   container_images: 5
+  container_image_tags: 13
   container_groups: 10
+  containers: 15
+  container_group_tags: 4
   container_nodes: 5
+  container_node_tags: 10
   container_projects: 2
+  container_project_tags: 7
   container_templates: 5
+  container_template_tags: 10
   flavors: 5
   service_instances: 10
   service_offerings: 2
+  service_offering_tags: 5
   service_offering_icons: 2
   service_plans: 5
   source_regions: 5
   volumes: 10              # belongs_to [:volume_type, :source_region]
+  volume_attachments: 2
   volume_types: 5
   vms: 10                  # belongs_to [:flavor]
+  vm_tags: 6

--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -157,7 +157,6 @@ module TopologicalInventory
         logger.info("[#{cnt}] Sweeping inactive records for #{entity_type} with :refresh_state_uuid => '#{refresh_state_uuid}'...")
 
         parsed_entity_types = [entity_type] + (storage_class.entity_types[entity_type] || []).flatten.compact
-        # parsed_entity_types = [entity_type]
 
         sweep_inventory(refresh_state_uuid,
                         total_parts,

--- a/lib/topological_inventory/mock_source/entity.rb
+++ b/lib/topological_inventory/mock_source/entity.rb
@@ -49,8 +49,9 @@ module TopologicalInventory
       def shared_tag_references
         {
           :tag => {
-            :name  => "mock-tag-#{@ref_id}",
-            :value => @ref_id.to_s
+            :name      => "mock-tag-#{@ref_id}",
+            :value     => @ref_id.to_s,
+            :namespace => 'mock-source' # eq. SourceType.name
           }
         }
       end

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -79,7 +79,7 @@ module TopologicalInventory
         # children per parent (rounded down)
         ratio = sub_total / parent_total
         idx = {}
-        # binding.pry if sub_entity_type == :container_group_tags
+
         # a) more sub_entities than parents
         #    - sub_entities generated in ratio except for last parent
         if ratio > 0
@@ -98,8 +98,8 @@ module TopologicalInventory
           idx[:end]   = parent_current < sub_total ? idx[:start] : -1
         end
 
-        (idx[:start]..idx[:end]).each do |idx|
-          yield sub_collection.get_entity(idx)
+        (idx[:start]..idx[:end]).each do |index|
+          yield sub_collection.get_entity(index)
         end
       end
 

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -61,13 +61,46 @@ module TopologicalInventory
         end
       end
 
-      def parse_sub_entity(entity_type, parent_entity)
+      def parse_sub_entity(sub_entity_type, parent_entity)
+        sub_entities(sub_entity_type, parent_entity) do |sub_entity|
+          parse_entity(sub_entity_type,
+                       sub_entity)
+        end
+      end
+
+      def sub_entities(sub_entity_type, parent_entity)
         storage = parent_entity.storage
+        sub_collection = storage.entities[sub_entity_type]
 
-        entity_collection = storage.entities[entity_type]
+        parent_current = parent_entity.ref_id # starts with idx == 0
+        parent_total   = parent_entity.entity_type.stats[:total].value
+        sub_total = sub_collection.stats[:total].value
 
-        parse_entity(entity_type,
-                     entity_collection.add_entity)
+        # children per parent (rounded down)
+        ratio = sub_total / parent_total
+        idx = {}
+        # binding.pry if sub_entity_type == :container_group_tags
+        # a) more sub_entities than parents
+        #    - sub_entities generated in ratio except for last parent
+        if ratio > 0
+          idx[:start] = ratio * parent_current
+
+          idx[:end] = if sub_total - idx[:start] >= ratio &&
+                         parent_current < parent_total - 1
+                        idx[:start] + ratio - 1
+                      else
+                        sub_total - 1
+                      end
+        # b) less sub_entities than parents
+        #    - sub_entities associated 1:1 until available
+        else
+          idx[:start] = parent_current
+          idx[:end]   = parent_current < sub_total ? idx[:start] : -1
+        end
+
+        (idx[:start]..idx[:end]).each do |idx|
+          yield sub_collection.get_entity(idx)
+        end
       end
 
       # Adds InventoryLazyObject with ref: :manager_ref to data

--- a/spec/parser/parser_spec.rb
+++ b/spec/parser/parser_spec.rb
@@ -43,7 +43,6 @@ describe TopologicalInventory::MockSource::Parser do
                            entity_types[entity_type])
     end
 
-
     assert_container_project(entities[:container_projects], @parser.collections[:container_projects].data.first)
     assert_container_node(entities[:container_nodes], @parser.collections[:container_nodes].data.first)
     assert_container_group(entities[:container_groups], @parser.collections[:container_groups].data.first)

--- a/spec/parser/parser_spec.rb
+++ b/spec/parser/parser_spec.rb
@@ -3,16 +3,23 @@ describe TopologicalInventory::MockSource::Parser do
 
   before do
     @amounts = {
-      :service_offerings      => 1,
-      :service_offering_icons => 1,
-      :service_plans          => 1,
-      :source_regions         => 1,
-      :container_projects     => 1,
-      :container_nodes        => 1,
-      :container_groups       => 1,
-      :service_instances      => 1,
-      :container_templates    => 1,
-      :container_images       => 1
+      :service_offerings       => 1,
+      :service_offering_tags   => 1,
+      :service_offering_icons  => 1,
+      :service_plans           => 1,
+      :source_regions          => 1,
+      :containers              => 1,
+      :container_projects      => 1,
+      :container_project_tags  => 1,
+      :container_nodes         => 1,
+      :container_node_tags     => 1,
+      :container_groups        => 1,
+      :container_group_tags    => 1,
+      :service_instances       => 1,
+      :container_templates     => 1,
+      :container_template_tags => 1,
+      :container_images        => 1,
+      :container_image_tags    => 1
     }
 
     stub_settings_merge(:refresh_mode   => :full_refresh,
@@ -29,12 +36,13 @@ describe TopologicalInventory::MockSource::Parser do
     entity_types = @storage.class.entity_types
     entities = {}
 
-    @amounts.each_key do |entity_type|
+    (@amounts.keys & @storage.class.entity_types.keys).each do |entity_type|
       entities[entity_type] = @storage.send(entity_type).get_entity(0)
       @parser.parse_entity(entity_type,
                            entities[entity_type],
                            entity_types[entity_type])
     end
+
 
     assert_container_project(entities[:container_projects], @parser.collections[:container_projects].data.first)
     assert_container_node(entities[:container_nodes], @parser.collections[:container_nodes].data.first)
@@ -205,7 +213,7 @@ describe TopologicalInventory::MockSource::Parser do
     expect(api_tag.class.name).to eq(api_class_name)
 
     # Name/value
-    assert_lazy_object(api_tag.tag, :name => "mock-tag-0", :value => "0")
+    assert_lazy_object(api_tag.tag, :name => "mock-tag-0", :value => "0", :namespace => "mock-source")
   end
 
   def assert_lazy_object(lazy_object, reference)

--- a/spec/parser/subcollections_spec.rb
+++ b/spec/parser/subcollections_spec.rb
@@ -1,0 +1,42 @@
+describe TopologicalInventory::MockSource::Parser do
+  let(:server) { TopologicalInventory::MockSource::Server.new }
+
+  (1..3).each do |projects_count|
+    (0..6).each do |project_tags_count|
+      context "with settings Projects count: #{projects_count}, Project tags count: #{project_tags_count}" do
+        before do
+          @amounts = {
+            :container_projects     => projects_count,
+            :container_project_tags => project_tags_count
+          }
+
+          stub_settings_merge(:refresh_mode   => :full_refresh,
+                              :multithreading => :off,
+                              :amounts        => @amounts)
+          @storage = TopologicalInventory::MockSource::Storage.new(server)
+          @storage.create_entities
+
+          @parser = TopologicalInventory::MockSource::Parser.new
+        end
+
+        it "creates correct number of tags" do
+          entity_types = @storage.class.entity_types
+
+          (0..@amounts[:container_projects] - 1).each do |idx|
+            container_project = @storage.container_projects.get_entity(idx)
+            @parser.parse_entity(:container_projects,
+                                 container_project,
+                                 entity_types[:container_projects])
+          end
+
+          assert_tags_count(project_tags_count)
+        end
+
+        def assert_tags_count(project_tags_count)
+          expect(@storage.container_project_tags.stats[:total].value).to eq(project_tags_count)
+          expect(@parser.collections[:container_project_tags].data.count).to eq(project_tags_count)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -5,3 +5,7 @@ def stub_settings_merge(hash)
   Settings.add_source!(hash)
   Settings.reload!
 end
+
+def clear_settings
+  ::Settings.keys.dup.each { |k| ::Settings.delete_field(k) }
+end


### PR DESCRIPTION
Amount config files now contains number of subcollections (tags, containers, volume_attachments).

When subcollections count >= parent collections count, they are distributed equally among parent collections. Remaining subcollections are associated with last parent. 

When subcollections count < parent collections count, then each parent is related with 1 subcollection until all subcollections are set, other parents has no associations