### PR TITLE
Configurable data

### DIFF
--- a/config/data/openshift/test.yml
+++ b/config/data/openshift/test.yml
@@ -18,6 +18,7 @@ data:
     service_offering_tags: 5
     service_plans: 5
     source_regions: 5
+  values:
 
 default_limit: 100 # Number of entities to send at once to ingress api
 

--- a/config/data/small.yml
+++ b/config/data/small.yml
@@ -24,3 +24,13 @@ data:
     volume_types: 5
     vms: 10                  # belongs_to [:flavor]
     vm_tags: 6
+#  values:
+#    flavors:
+#      cpus: 120
+#      extra:
+#        attributes:
+#          test: kvrk
+#    service_offerings:
+#      service_offering_icon:
+#        source_ref: mock-service_offering_icons-0000000000
+#      source_region: nil

--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -212,7 +212,7 @@ module TopologicalInventory
 
       def initialize_config(settings_config, data_config)
         settings_file = File.join(path_to_defaults_config, "#{sanitize_filename(settings_config)}.yml")
-        data_file  = File.join(path_to_data_config, "#{sanitize_filename(data_config)}.yml")
+        data_file     = File.join(path_to_data_config, "#{sanitize_filename(data_config)}.yml")
 
         raise "Settings configuration file #{settings_config} doesn't exist" unless File.exist?(settings_file)
         raise "Data configuration file #{data_config} doesn't exist" unless File.exist?(data_file)

--- a/lib/topological_inventory/mock_source/entity/container.rb
+++ b/lib/topological_inventory/mock_source/entity/container.rb
@@ -13,7 +13,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :container_group => {:source_ref => link_to(:container_groups)},
           :container_image => {:source_ref => link_to(:container_images)}

--- a/lib/topological_inventory/mock_source/entity/container_group.rb
+++ b/lib/topological_inventory/mock_source/entity/container_group.rb
@@ -14,7 +14,7 @@ module TopologicalInventory
         )
       end
 
-      def references
+      def references_hash
         {
           :container_node    => {:name => link_to(:container_nodes, :ref => :name)},
           :container_project => {:name => link_to(:container_projects, :ref => :name)}

--- a/lib/topological_inventory/mock_source/entity/container_group_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/container_group_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ContainerGroupTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :container_group => {:source_ref => link_to(:container_groups)}
         )

--- a/lib/topological_inventory/mock_source/entity/container_image_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/container_image_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ContainerImageTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :container_image => {:source_ref => link_to(:container_images)}
         )

--- a/lib/topological_inventory/mock_source/entity/container_node.rb
+++ b/lib/topological_inventory/mock_source/entity/container_node.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
         )
       end
 
-      def references
+      def references_hash
         {
           :cross_link_vms => {:uid_ems => nil} # TODO: link_to(:vms)
         }

--- a/lib/topological_inventory/mock_source/entity/container_node_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/container_node_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ContainerNodeTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :container_node => {:source_ref => link_to(:container_nodes)}
         )

--- a/lib/topological_inventory/mock_source/entity/container_project_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/container_project_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ContainerProjectTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :container_project => {:source_ref => link_to(:container_projects)}
         )

--- a/lib/topological_inventory/mock_source/entity/container_template.rb
+++ b/lib/topological_inventory/mock_source/entity/container_template.rb
@@ -7,7 +7,7 @@ module TopologicalInventory
         shared_attributes
       end
 
-      def references
+      def references_hash
         {
           :container_project => {:name => link_to(:container_projects, :ref => :name)}
         }

--- a/lib/topological_inventory/mock_source/entity/container_template_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/container_template_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ContainerTemplateTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :container_template => {:source_ref => link_to(:container_templates)}
         )

--- a/lib/topological_inventory/mock_source/entity/service_instance.rb
+++ b/lib/topological_inventory/mock_source/entity/service_instance.rb
@@ -13,7 +13,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :service_plan     => {:source_ref => link_to(:service_plans)},
           :service_offering => {:source_ref => link_to(:service_offerings)},

--- a/lib/topological_inventory/mock_source/entity/service_offering.rb
+++ b/lib/topological_inventory/mock_source/entity/service_offering.rb
@@ -17,7 +17,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :service_offering_icon => {:source_ref => link_to(:service_offering_icons)},
           :source_region         => {:source_ref => link_to(:source_regions)}

--- a/lib/topological_inventory/mock_source/entity/service_offering_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/service_offering_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::ServiceOfferingTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :service_offering => {:source_ref => link_to(:service_offerings)}
         )

--- a/lib/topological_inventory/mock_source/entity/service_plan.rb
+++ b/lib/topological_inventory/mock_source/entity/service_plan.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
         )
       end
 
-      def references
+      def references_hash
         {
           :service_offering => {:source_ref => link_to(:service_offerings)},
           :source_region    => {:source_ref => link_to(:source_regions)}

--- a/lib/topological_inventory/mock_source/entity/vm.rb
+++ b/lib/topological_inventory/mock_source/entity/vm.rb
@@ -13,7 +13,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :flavor => {:source_ref => link_to(:flavors)}
         }

--- a/lib/topological_inventory/mock_source/entity/vm_tag.rb
+++ b/lib/topological_inventory/mock_source/entity/vm_tag.rb
@@ -3,7 +3,7 @@ require "topological_inventory/mock_source/entity"
 module TopologicalInventory
   module MockSource
     class Entity::VmTag < Entity
-      def references
+      def references_hash
         shared_tag_references.merge(
           :vm => {:source_ref => link_to(:vms)}
         )

--- a/lib/topological_inventory/mock_source/entity/volume.rb
+++ b/lib/topological_inventory/mock_source/entity/volume.rb
@@ -14,7 +14,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :volume_type   => {:source_ref => link_to(:volume_types)},
           :source_region => {:source_ref => link_to(:source_regions)}

--- a/lib/topological_inventory/mock_source/entity/volume_attachment.rb
+++ b/lib/topological_inventory/mock_source/entity/volume_attachment.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
         }
       end
 
-      def references
+      def references_hash
         {
           :volume => {:source_ref => link_to(:volumes)},
           :vm     => {:source_ref => link_to(:vms)},

--- a/lib/topological_inventory/mock_source/entity_type.rb
+++ b/lib/topological_inventory/mock_source/entity_type.rb
@@ -166,7 +166,7 @@ module TopologicalInventory
 
       # TODO
       def assert_objects_count(dest_entity_type)
-        amounts=::Settings.data&.amounts || {}
+        amounts = ::Settings.data&.amounts || {}
         if amounts[dest_entity_type].to_i == 0
           # TODO: can be nil in the future
           raise "Nil config on #{dest_entity_type}"

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -46,6 +46,10 @@ module TopologicalInventory
         inventory_object.source_deleted_at = source_deleted_at
       end
 
+      def lazy_find(collection, reference, ref: :manager_ref)
+        super unless reference.nil?
+      end
+
       protected
 
       def parse_entity_simple(entity_type, entity)

--- a/lib/topological_inventory/mock_source/parser/custom_parsing.rb
+++ b/lib/topological_inventory/mock_source/parser/custom_parsing.rb
@@ -2,12 +2,13 @@ module TopologicalInventory
   module MockSource
     class Parser
       module CustomParsing
+        # TODO: custom lazy link values
         def parse_container_group(entity, sub_entity_types)
           inventory_object = parse_entity_simple(:container_groups, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.container_node    = lazy_find_container_node(entity.references[:container_node])
-          inventory_object.container_project = lazy_find_container_project(entity.references[:container_project])
+          inventory_object.container_node    = lazy_find_container_node(entity.references_hash[:container_node])
+          inventory_object.container_project = lazy_find_container_project(entity.references_hash[:container_project])
           inventory_object
         end
 
@@ -15,7 +16,7 @@ module TopologicalInventory
           inventory_object = parse_entity_simple(:container_nodes, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.lives_on = lazy_find(:cross_link_vms, entity.references[:cross_link_vms])
+          inventory_object.lives_on = lazy_find(:cross_link_vms, entity.references_hash[:cross_link_vms])
           inventory_object
         end
 
@@ -23,7 +24,7 @@ module TopologicalInventory
           inventory_object = parse_entity_simple(:container_templates, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.container_project = lazy_find_container_project(entity.references[:container_project])
+          inventory_object.container_project = lazy_find_container_project(entity.references_hash[:container_project])
           inventory_object
         end
       end

--- a/lib/topological_inventory/mock_source/parser/custom_parsing.rb
+++ b/lib/topological_inventory/mock_source/parser/custom_parsing.rb
@@ -2,13 +2,12 @@ module TopologicalInventory
   module MockSource
     class Parser
       module CustomParsing
-        # TODO: custom lazy link values
         def parse_container_group(entity, sub_entity_types)
           inventory_object = parse_entity_simple(:container_groups, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.container_node    = lazy_find_container_node(entity.references_hash[:container_node])
-          inventory_object.container_project = lazy_find_container_project(entity.references_hash[:container_project])
+          inventory_object.container_node    = lazy_find_container_node(entity.references[:container_node])
+          inventory_object.container_project = lazy_find_container_project(entity.references[:container_project])
           inventory_object
         end
 
@@ -16,7 +15,7 @@ module TopologicalInventory
           inventory_object = parse_entity_simple(:container_nodes, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.lives_on = lazy_find(:cross_link_vms, entity.references_hash[:cross_link_vms])
+          inventory_object.lives_on = lazy_find(:cross_link_vms, entity.references[:cross_link_vms])
           inventory_object
         end
 
@@ -24,7 +23,7 @@ module TopologicalInventory
           inventory_object = parse_entity_simple(:container_templates, entity)
           parse_sub_entities(sub_entity_types, entity)
 
-          inventory_object.container_project = lazy_find_container_project(entity.references_hash[:container_project])
+          inventory_object.container_project = lazy_find_container_project(entity.references[:container_project])
           inventory_object
         end
       end

--- a/scripts/openshift/config_maps/custom-mock-data.yml
+++ b/scripts/openshift/config_maps/custom-mock-data.yml
@@ -21,3 +21,6 @@ data:
         volumes: 10
         volume_types: 5
         vms: 6
+      values:
+        flavors:
+          cpus: 100

--- a/spec/parser/custom_data_spec.rb
+++ b/spec/parser/custom_data_spec.rb
@@ -23,6 +23,7 @@ describe TopologicalInventory::MockSource::Parser do
   end
 
   before do
+    init_settings
     stub_settings_merge(:refresh_mode   => :full_refresh,
                         :multithreading => :off,
                         :data           => {

--- a/spec/parser/custom_data_spec.rb
+++ b/spec/parser/custom_data_spec.rb
@@ -1,0 +1,84 @@
+describe TopologicalInventory::MockSource::Parser do
+  let(:server) { TopologicalInventory::MockSource::Server.new }
+  let(:amounts) do
+    {:service_offerings      => 2,
+     :service_offering_tags  => 1,
+     :service_offering_icons => 2,
+     :source_regions         => 1}
+  end
+  let(:custom_display_name) { "Custom display name" }
+
+  let(:values) do
+    {
+      :service_offerings     => {
+        :display_name          => custom_display_name,
+        :service_offering_icon => {
+          :source_ref => "custom_source_ref"
+        }
+      },
+      :service_offering_tags => {
+        :service_offering => nil
+      }
+    }
+  end
+
+  before do
+    stub_settings_merge(:refresh_mode   => :full_refresh,
+                        :multithreading => :off,
+                        :data           => {
+                          :amounts => amounts,
+                          :values  => values
+                        })
+    @storage = TopologicalInventory::MockSource::Storage.new(server)
+    @storage.create_entities
+
+    @parser = TopologicalInventory::MockSource::Parser.new
+  end
+
+  it "changes data according to values" do
+    entity_types = @storage.class.entity_types
+    entities     = {}
+
+    (amounts.keys & @storage.class.entity_types.keys).each do |entity_type|
+      amounts[entity_type].times do |idx|
+        entities[entity_type] = @storage.send(entity_type).get_entity(idx)
+        @parser.parse_entity(entity_type,
+                             entities[entity_type],
+                             entity_types[entity_type])
+      end
+    end
+
+    assert_counts
+    assert_service_offerings
+    assert_service_offering_tags
+  end
+
+  def assert_counts
+    amounts.each_pair do |name, amount|
+      expect(@storage.send(name).stats[:total].value).to eq(amount)
+      expect(@parser.collections[name].data.count).to eq(amount)
+    end
+  end
+
+  def assert_service_offerings
+    amounts[:service_offerings].times do |idx|
+      service_offering = @parser.collections[:service_offerings].data[idx]
+      # same as Entity::ServiceOffering definition
+      expect(service_offering.name).to eq("mock-serviceoffering-#{idx}")
+      expect(service_offering.support_url).to eq("http://example.com/support/")
+      # changed by settings
+      expect(service_offering.display_name).to eq(custom_display_name)
+      expect(service_offering.service_offering_icon.reference).to eq(:source_ref => "custom_source_ref")
+    end
+  end
+
+  def assert_service_offering_tags
+    amounts[:service_offering_tags].times do |idx|
+      tag = @parser.collections[:service_offering_tags].data[idx]
+      expect(tag.tag.reference).to eq(:name      => "mock-tag-#{idx}",
+                                      :value     => idx.to_s,
+                                      :namespace => 'mock-source')
+      expect(tag.service_offering).to eq(nil)
+    end
+  end
+end

--- a/spec/parser/parser_spec.rb
+++ b/spec/parser/parser_spec.rb
@@ -22,6 +22,7 @@ describe TopologicalInventory::MockSource::Parser do
       :container_image_tags    => 1
     }
 
+    init_settings
     stub_settings_merge(:refresh_mode   => :full_refresh,
                         :multithreading => :off,
                         :data           => { :amounts => @amounts })

--- a/spec/parser/subcollections_spec.rb
+++ b/spec/parser/subcollections_spec.rb
@@ -10,6 +10,7 @@ describe TopologicalInventory::MockSource::Parser do
             :container_project_tags => project_tags_count
           }
 
+          init_settings
           stub_settings_merge(:refresh_mode   => :full_refresh,
                               :multithreading => :off,
                               :data           => { :amounts => @amounts })

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -1,11 +1,19 @@
-path_to_config = File.expand_path("../../config", File.dirname(__FILE__))
-::Config.load_and_set_settings(File.join(path_to_config, 'simple.yml'), File.join("#{path_to_config}/data/openshift", 'test.yml'))
+def init_settings
+  clear_settings
+
+  path_to_config = File.expand_path("../../config", File.dirname(__FILE__))
+  ::Config.load_and_set_settings(File.join(path_to_config, 'simple.yml'), File.join("#{path_to_config}/data/openshift", 'test.yml'))
+end
 
 def stub_settings_merge(hash)
-  Settings.add_source!(hash)
-  Settings.reload!
+  if defined?(::Settings)
+    Settings.add_source!(hash)
+    Settings.reload!
+  end
 end
 
 def clear_settings
-  ::Settings.keys.dup.each { |k| ::Settings.delete_field(k) }
+  ::Settings.keys.dup.each { |k| ::Settings.delete_field(k) } if defined?(::Settings)
 end
+
+init_settings


### PR DESCRIPTION
Data config can contain custom values, which will replace specified column for all records:
Other columns remain unaffected.
Example:
```
data:
  values:
    flavors:
      cpus: 120
      extra:
        attributes:
          test: kvrk
    service_offerings:
      service_offering_icon:
        source_ref: mock-service_offering_icons-0000000000
      source_region: nil
```

---

* [x] depends on #23 