### PR TITLE
Correct resource version type is string

### DIFF
--- a/lib/topological_inventory/mock_source/entity.rb
+++ b/lib/topological_inventory/mock_source/entity.rb
@@ -104,7 +104,7 @@ module TopologicalInventory
       end
 
       def resource_version_timestamp
-        Time.new.to_i
+        Time.new.to_i.to_s
       end
 
       # Ratio of default values:timestamps for resource version in percents


### PR DESCRIPTION
With new ingress validation, it must be string or it's won't pass