### PR TITLE
Removing Collector-Saver dependency

### DIFF
--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -6,7 +6,6 @@ require "topological_inventory/mock_source/parser"
 require "topological_inventory/mock_source/server"
 require "topological_inventory/mock_source/storage"
 require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/save_inventory/saver"
 
 module TopologicalInventory
   module MockSource


### PR DESCRIPTION
require moved to ingress-api-client-ruby

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/38