### PR TITLE
Moving collector's common from ingress-api-client-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "kubeclient"
 gem "more_core_extensions"
 gem "optimist"
 gem "recursive-open-struct"
-gem "manageiq-loggers", "~> 0.1.1"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
+gem "topological_inventory-providers-common",   :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 
 group :development, :test do
   gem "rspec", "~> 3.0"

--- a/lib/topological_inventory/mock_source/collector.rb
+++ b/lib/topological_inventory/mock_source/collector.rb
@@ -1,15 +1,14 @@
 require "config"
 require "concurrent"
-require "topological_inventory-ingress_api-client/collector"
+require "topological_inventory/providers/common/collector"
 require "topological_inventory/mock_source/logging"
 require "topological_inventory/mock_source/parser"
 require "topological_inventory/mock_source/server"
 require "topological_inventory/mock_source/storage"
-require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory
   module MockSource
-    class Collector < TopologicalInventoryIngressApiClient::Collector
+    class Collector < TopologicalInventory::Providers::Common::Collector
       include Logging
 
       def initialize(source, config, data)

--- a/lib/topological_inventory/mock_source/parser.rb
+++ b/lib/topological_inventory/mock_source/parser.rb
@@ -1,6 +1,8 @@
+require "topological_inventory/providers/common/collector/parser"
+
 module TopologicalInventory
   module MockSource
-    class Parser < TopologicalInventoryIngressApiClient::Collector::Parser
+    class Parser < TopologicalInventory::Providers::Common::Collector::Parser
       require "topological_inventory/mock_source/parser/custom_lazy_find"
       require "topological_inventory/mock_source/parser/custom_parsing"
       include TopologicalInventory::MockSource::Parser::CustomLazyFind

--- a/scripts/config
+++ b/scripts/config
@@ -6,8 +6,13 @@ openshift_project="test-mslemr"
 # It serves as tenant's authorization. For our purpose, account number can be any value.
 # Creates records in "tenants" db tables
 # And used as x-rh-identity header for curl requests.
-plain_rh_identity="{\"identity\":{\"account_number\":\"test-mock\"}}"
-export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64)
+plain_rh_identity="{\"identity\":{\"account_number\":\"test-mock\"}, \"internal\": {\"org_id\": \"54321\"}}"
+
+# base64 can split output to more lines, forbid it with one of following
+# depends on base64 version:
+#export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64)
+export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64 --wrap=0)
+# export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64 --break=0)
 
 # Topological API service
 # Create routes in openshift to get these hosts


### PR DESCRIPTION
to providers-common gem, because ingress-api-client is built from generator

---

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-providers-common/pull/1
