### PR TITLE
Updated ContainerNode and Volume

### DIFF
--- a/lib/topological_inventory/mock_source/entity/container_node.rb
+++ b/lib/topological_inventory/mock_source/entity/container_node.rb
@@ -12,7 +12,7 @@ module TopologicalInventory
 
       def references_hash
         {
-          :cross_link_vms => {:uid_ems => nil} # TODO: link_to(:vms)
+          # :cross_link_vms => {:uid_ems => nil} # TODO: link_to(:vms)
         }
       end
     end

--- a/lib/topological_inventory/mock_source/entity/container_node.rb
+++ b/lib/topological_inventory/mock_source/entity/container_node.rb
@@ -9,12 +9,6 @@ module TopologicalInventory
           :memory => 134_902_530_048,
         )
       end
-
-      def references_hash
-        {
-          # :cross_link_vms => {:uid_ems => nil} # TODO: link_to(:vms)
-        }
-      end
     end
   end
 end

--- a/lib/topological_inventory/mock_source/entity/volume.rb
+++ b/lib/topological_inventory/mock_source/entity/volume.rb
@@ -7,8 +7,7 @@ module TopologicalInventory
         {
           :source_ref        => @uid,
           :name              => @name,
-          :uid_ems           => @uid,
-          :power_state       => power_states.sample,
+          :state             => power_states.sample,
           :source_created_at => @created_at,
           :size              => 2 * 1024**3,
         }


### PR DESCRIPTION
VmsCrossLinks are not a standard link, removed. 
Volume's columns changed