### PR TITLE
Add travis config and Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+language: ruby
+cache: bundler
+rvm:
+- 2.5.7
+- 2.6.5
+before_install:
+- 'echo ''gem: --no-ri --no-rdoc --no-document'' > ~/.gemrc'
+- gem install bundler
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+  > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- "./cc-test-reporter before-build"
+after_script:
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "activesupport"
+gem "activesupport", '>= 5.2.2.1', '~> 5.2.2'
 gem "concurrent-ruby"
 gem "config"
 gem "kubeclient"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
+task default: :spec


### PR DESCRIPTION
Files copied from https://github.com/RedHatInsights/topological_inventory-amazon

Also, added gem versioning in `Gemfile` for `activesupport` to fix Hakiri warning.  Version now matches the rails version used in https://github.com/RedHatInsights/topological_inventory-api

Note: Travis test failure was pre-existing and unrelated to this PR.  I recommend we merge this so since it introduces travis testing on each PR.  The failing test should be fixed in a followup PR.