### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -27,5 +27,5 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-69
+    channel: rubocop-1-0
     config: ".rubocop_cc.yml"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -27,5 +27,5 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-0
+    channel: rubocop-0-69
     config: ".rubocop_cc.yml"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 # put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
 - .rubocop_local.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from:
-- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
 # put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
 - .rubocop_local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ gem "topological_inventory-providers-common",   :git => "https://github.com/RedH
 
 group :development, :test do
   gem "rspec", "~> 3.0"
-  gem 'rubocop',             "~>0.69.0", :require => false
-  gem 'rubocop-performance', "~>1.3",    :require => false
-  gem "simplecov",           "~>0.17.1"
+  gem "rubocop",             "~> 1.0.0", :require => false
+  gem "rubocop-performance", "~> 1.8",   :require => false
+  gem "rubocop-rails",       "~> 2.8",   :require => false
+  gem "simplecov",           "~> 0.17.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,7 @@ gem "topological_inventory-providers-common",   :git => "https://github.com/RedH
 
 group :development, :test do
   gem "rspec", "~> 3.0"
-  gem "rubocop",             "~> 1.0.0", :require => false
-  gem "rubocop-performance", "~> 1.8",   :require => false
-  gem "rubocop-rails",       "~> 2.8",   :require => false
+  gem 'rubocop',             "~>0.69.0", :require => false
+  gem 'rubocop-performance', "~>1.3",    :require => false
   gem "simplecov",           "~>0.17.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ gem "topological_inventory-providers-common",   :git => "https://github.com/RedH
 
 group :development, :test do
   gem "rspec", "~> 3.0"
-  gem 'rubocop',             "~>0.69.0", :require => false
-  gem 'rubocop-performance', "~>1.3",    :require => false
+  gem "rubocop",             "~> 1.0.0", :require => false
+  gem "rubocop-performance", "~> 1.8",   :require => false
+  gem "rubocop-rails",       "~> 2.8",   :require => false
   gem "simplecov",           "~>0.17.1"
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
