### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mock collector for OpenShift
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-mock_source.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-mock_source)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-mock_source.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-mock_source)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a9786a524995131c01a4/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-mock_source/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/a9786a524995131c01a4/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-mock_source/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-mock_source/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-mock_source/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.